### PR TITLE
Fix yandex geocoder request scheme

### DIFF
--- a/library/yandex/core.yandex-geocoder.js
+++ b/library/yandex/core.yandex-geocoder.js
@@ -85,7 +85,7 @@ function GeocodeCallback(data)
 jsMaps.Yandex.prototype.addressGeoSearch = function (search, fun) {
     fn = fun;
     var script = document.createElement('script');
-    script.src = 'http://geocode-maps.yandex.ru/1.x/?geocode=' + search + '&lang=en-US&format=json&callback=GeocodeCallback';
+    script.src = '//geocode-maps.yandex.ru/1.x/?geocode=' + search + '&lang=en-US&format=json&callback=GeocodeCallback';
 
     document.getElementsByTagName('head')[0].appendChild(script);
 };

--- a/library/yandex/core.yandex-geocoder.js
+++ b/library/yandex/core.yandex-geocoder.js
@@ -94,6 +94,6 @@ function GeocodeCallbackFactory(fn) {
  */
 jsMaps.Yandex.prototype.addressGeoSearch = function (search, fun) {
     var script = document.createElement('script');
-    script.src = '//geocode-maps.yandex.ru/1.x/?geocode=' + search + '&lang=en-US&format=json&callback=GeocodeCallback';
+    script.src = '//geocode-maps.yandex.ru/1.x/?geocode=' + search + '&lang=en-US&format=json&callback='+GeocodeCallbackFactory(fun);
     document.getElementsByTagName('head')[0].appendChild(script);
 };


### PR DESCRIPTION
Now HTTP used for yandex driver geocoder request.
This will cause the problem if page loaded with HTTPS, because of mixed content.
I changed http:// to //, which is correct for http and https both.